### PR TITLE
fix: downgrade `semantic-release` for node 12 comptaibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13601,16 +13601,16 @@
       }
     },
     "semantic-release": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-18.0.0.tgz",
-      "integrity": "sha512-/Szyhq5DTZCYry/aZqpBbK/kqv10ydn6oiiaYOXtPgDbAIkqidZcQOm+mfYFJ0sBTUaOYCKMlcPMgJycP7jDYQ==",
+      "version": "17.4.7",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-17.4.7.tgz",
+      "integrity": "sha512-3Ghu8mKCJgCG3QzE5xphkYWM19lGE3XjFdOXQIKBM2PBpBvgFQ/lXv31oX0+fuN/UjNFO/dqhNs8ATLBhg6zBg==",
       "dev": true,
       "requires": {
-        "@semantic-release/commit-analyzer": "^9.0.0",
-        "@semantic-release/error": "^3.0.0",
-        "@semantic-release/github": "^8.0.0",
-        "@semantic-release/npm": "^8.0.0",
-        "@semantic-release/release-notes-generator": "^10.0.0",
+        "@semantic-release/commit-analyzer": "^8.0.0",
+        "@semantic-release/error": "^2.2.0",
+        "@semantic-release/github": "^7.0.0",
+        "@semantic-release/npm": "^7.0.0",
+        "@semantic-release/release-notes-generator": "^9.0.0",
         "aggregate-error": "^3.0.0",
         "cosmiconfig": "^7.0.0",
         "debug": "^4.0.0",
@@ -13636,183 +13636,6 @@
         "yargs": "^16.2.0"
       },
       "dependencies": {
-        "@octokit/core": {
-          "version": "3.5.1",
-          "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.5.1.tgz",
-          "integrity": "sha512-omncwpLVxMP+GLpLPgeGJBF6IWJFjXDS5flY5VbppePYX9XehevbDykRH9PdCdvqt9TS5AOTiDide7h0qrkHjw==",
-          "dev": true,
-          "requires": {
-            "@octokit/auth-token": "^2.4.4",
-            "@octokit/graphql": "^4.5.8",
-            "@octokit/request": "^5.6.0",
-            "@octokit/request-error": "^2.0.5",
-            "@octokit/types": "^6.0.3",
-            "before-after-hook": "^2.2.0",
-            "universal-user-agent": "^6.0.0"
-          }
-        },
-        "@octokit/plugin-rest-endpoint-methods": {
-          "version": "5.11.4",
-          "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.11.4.tgz",
-          "integrity": "sha512-iS+GYTijrPUiEiLoDsGJhrbXIvOPfm2+schvr+FxNMs7PeE9Nl4bAMhE8ftfNX3Z1xLxSKwEZh0O7GbWurX5HQ==",
-          "dev": true,
-          "requires": {
-            "@octokit/types": "^6.31.2",
-            "deprecation": "^2.3.1"
-          }
-        },
-        "@octokit/rest": {
-          "version": "18.11.4",
-          "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.11.4.tgz",
-          "integrity": "sha512-QplypCyYxqMK05JdMSm/bDWZO8VWWaBdzQ9tbF9rEV9rIEiICh+v6q+Vu/Y5hdze8JJaxfUC+PBC7vrnEkZvZg==",
-          "dev": true,
-          "requires": {
-            "@octokit/core": "^3.5.1",
-            "@octokit/plugin-paginate-rest": "^2.16.4",
-            "@octokit/plugin-request-log": "^1.0.4",
-            "@octokit/plugin-rest-endpoint-methods": "5.11.4"
-          }
-        },
-        "@octokit/types": {
-          "version": "6.31.3",
-          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.31.3.tgz",
-          "integrity": "sha512-IUG3uMpsLHrtEL6sCVXbxCgnbKcgpkS4K7gVEytLDvYYalkK3XcuMCHK1YPD8xJglSJAOAbL4MgXp47rS9G49w==",
-          "dev": true,
-          "requires": {
-            "@octokit/openapi-types": "^10.6.4"
-          }
-        },
-        "@semantic-release/commit-analyzer": {
-          "version": "9.0.1",
-          "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-9.0.1.tgz",
-          "integrity": "sha512-ncNsnrLmiykhgNZUXNvhhAjNN0me7VGIb0X5hu3ogyi5DDPapjGAHdEffO5vi+HX1BFWLRD/Ximx5PjGAKjAqQ==",
-          "dev": true,
-          "requires": {
-            "conventional-changelog-angular": "^5.0.0",
-            "conventional-commits-filter": "^2.0.0",
-            "conventional-commits-parser": "^3.0.7",
-            "debug": "^4.0.0",
-            "import-from": "^4.0.0",
-            "lodash": "^4.17.4",
-            "micromatch": "^4.0.2"
-          }
-        },
-        "@semantic-release/error": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-3.0.0.tgz",
-          "integrity": "sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw==",
-          "dev": true
-        },
-        "@semantic-release/github": {
-          "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-8.0.1.tgz",
-          "integrity": "sha512-T01lfh4yBZodAeo8t0U+W5hmPYR9BdnfwLDerXnGaYeLXm8+KMx4mQEBAf/UbRVlzmIKTqMx+/s9fY/mSQNV0A==",
-          "dev": true,
-          "requires": {
-            "@octokit/rest": "^18.0.0",
-            "@semantic-release/error": "^2.2.0",
-            "aggregate-error": "^3.0.0",
-            "bottleneck": "^2.18.1",
-            "debug": "^4.0.0",
-            "dir-glob": "^3.0.0",
-            "fs-extra": "^10.0.0",
-            "globby": "^11.0.0",
-            "http-proxy-agent": "^5.0.0",
-            "https-proxy-agent": "^5.0.0",
-            "issue-parser": "^6.0.0",
-            "lodash": "^4.17.4",
-            "mime": "^2.4.3",
-            "p-filter": "^2.0.0",
-            "p-retry": "^4.0.0",
-            "url-join": "^4.0.0"
-          },
-          "dependencies": {
-            "@semantic-release/error": {
-              "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-2.2.0.tgz",
-              "integrity": "sha512-9Tj/qn+y2j+sjCI3Jd+qseGtHjOAeg7dU2/lVcqIQ9TV3QDaDXDYXcoOHU+7o2Hwh8L8ymL4gfuO7KxDs3q2zg==",
-              "dev": true
-            }
-          }
-        },
-        "@semantic-release/npm": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-8.0.0.tgz",
-          "integrity": "sha512-MAlynjIaN5XwBEzsq3xbZ8I+riD9zhLvpPqGCPaZ0j/ySbR0Sg3YG1MYv03fC1aygPFFC5RwefMxKids9llvDg==",
-          "dev": true,
-          "requires": {
-            "@semantic-release/error": "^2.2.0",
-            "aggregate-error": "^3.0.0",
-            "execa": "^5.0.0",
-            "fs-extra": "^10.0.0",
-            "lodash": "^4.17.15",
-            "nerf-dart": "^1.0.0",
-            "normalize-url": "^6.0.0",
-            "npm": "^7.0.0",
-            "rc": "^1.2.8",
-            "read-pkg": "^5.0.0",
-            "registry-auth-token": "^4.0.0",
-            "semver": "^7.1.2",
-            "tempy": "^1.0.0"
-          },
-          "dependencies": {
-            "@semantic-release/error": {
-              "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-2.2.0.tgz",
-              "integrity": "sha512-9Tj/qn+y2j+sjCI3Jd+qseGtHjOAeg7dU2/lVcqIQ9TV3QDaDXDYXcoOHU+7o2Hwh8L8ymL4gfuO7KxDs3q2zg==",
-              "dev": true
-            }
-          }
-        },
-        "@semantic-release/release-notes-generator": {
-          "version": "10.0.2",
-          "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-10.0.2.tgz",
-          "integrity": "sha512-I4eavIcDan8fNQHskZ2cbWkFMimvgxNkqR2UfuYNwYBgswEl3SJsN8XMf9gZWObt6nXDc2QfDwhjy8DjTZqS3w==",
-          "dev": true,
-          "requires": {
-            "conventional-changelog-angular": "^5.0.0",
-            "conventional-changelog-writer": "^5.0.0",
-            "conventional-commits-filter": "^2.0.0",
-            "conventional-commits-parser": "^3.0.0",
-            "debug": "^4.0.0",
-            "get-stream": "^6.0.0",
-            "import-from": "^4.0.0",
-            "into-stream": "^6.0.0",
-            "lodash": "^4.17.4",
-            "read-pkg-up": "^7.0.0"
-          }
-        },
-        "@tootallnate/once": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-          "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
-          "dev": true
-        },
-        "conventional-changelog-writer": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-5.0.0.tgz",
-          "integrity": "sha512-HnDh9QHLNWfL6E1uHz6krZEQOgm8hN7z/m7tT16xwd802fwgMN0Wqd7AQYVkhpsjDUx/99oo+nGgvKF657XP5g==",
-          "dev": true,
-          "requires": {
-            "conventional-commits-filter": "^2.0.7",
-            "dateformat": "^3.0.0",
-            "handlebars": "^4.7.6",
-            "json-stringify-safe": "^5.0.1",
-            "lodash": "^4.17.15",
-            "meow": "^8.0.0",
-            "semver": "^6.0.0",
-            "split": "^1.0.0",
-            "through2": "^4.0.0"
-          },
-          "dependencies": {
-            "semver": {
-              "version": "6.3.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-              "dev": true
-            }
-          }
-        },
         "figures": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -13836,23 +13659,6 @@
           "version": "6.0.1",
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
           "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-          "dev": true
-        },
-        "http-proxy-agent": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
-          "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
-          "dev": true,
-          "requires": {
-            "@tootallnate/once": "2",
-            "agent-base": "6",
-            "debug": "4"
-          }
-        },
-        "import-from": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/import-from/-/import-from-4.0.0.tgz",
-          "integrity": "sha512-P9J71vT5nLlDeV8FHs5nNxaLbrpfAV5cF5srvbZfpwpcJoM/xZR3hiv+q+SAnuSmuGbXMWud063iIMx/V/EWZQ==",
           "dev": true
         },
         "locate-path": {
@@ -13922,6 +13728,14 @@
             "normalize-package-data": "^2.5.0",
             "parse-json": "^5.0.0",
             "type-fest": "^0.6.0"
+          },
+          "dependencies": {
+            "type-fest": {
+              "version": "0.6.0",
+              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+              "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+              "dev": true
+            }
           }
         },
         "read-pkg-up": {
@@ -13933,14 +13747,6 @@
             "find-up": "^4.1.0",
             "read-pkg": "^5.2.0",
             "type-fest": "^0.8.1"
-          },
-          "dependencies": {
-            "type-fest": {
-              "version": "0.8.1",
-              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-              "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-              "dev": true
-            }
           }
         },
         "semver": {
@@ -13953,15 +13759,9 @@
           }
         },
         "type-fest": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-          "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
-          "dev": true
-        },
-        "universal-user-agent": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
-          "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==",
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
           "dev": true
         },
         "yargs": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "jest": "^27.2.4",
     "jest-junit": "^12.3.0",
     "prettier": "^2.4.1",
-    "semantic-release": "^18.0.0",
+    "semantic-release": "^17.4.7",
     "ts-jest": "^27.0.5",
     "typescript": "^4.4.3"
   },


### PR DESCRIPTION
Fixing release: `semantic-release` 18 requires `node` 14.